### PR TITLE
Update BlockPreviewController.cs

### DIFF
--- a/Knowit.Umbraco.Bellissima.InstantBlockPreview/Controllers/BlockPreviewController.cs
+++ b/Knowit.Umbraco.Bellissima.InstantBlockPreview/Controllers/BlockPreviewController.cs
@@ -102,7 +102,7 @@ namespace Knowit.Umbraco.Bellissima.InstantBlockPreview.Controllers
                     foreach (var item in blm)
                     {
                         bli = _blockHelper.DigForBlockListItem(item, payloadContentExtractor.Target);
-                        if (bgi != null) break;
+                        if (bli != null) break;
                     }
                     controllerName = bli.Content.ContentType.Alias;
                 }


### PR DESCRIPTION
Fix for multiple previews not loading correctly. 'bgi' was probably copied from blockgrids but it should be 'bli' here, that fixes the issue. 